### PR TITLE
updated AbstractContent::getData to ignore null type

### DIFF
--- a/ClassContent/AbstractContent.php
+++ b/ClassContent/AbstractContent.php
@@ -944,6 +944,9 @@ abstract class AbstractContent implements ObjectIdentifiableInterface, Renderabl
             } elseif ('array' !== $type) {
                 try {
                     $type = self::getFullClassname($type);
+                    if (false == $type) {
+                        continue;
+                    }
                 } catch (\InvalidArgumentException $e) {
                     throw new ClassNotFoundException(sprintf('Unknown class content %s.', $type), 0, $e);
                 }


### PR DESCRIPTION
This PR aims to avoid error like `PHP Fatal error:  Class name must be a valid object or a string in /vendor/backbee/backbee-php/ClassContent/AbstractContent.php on line 751` which occurs if classcontent that does not exist anymore still remain in your database and `bbapp.classcontent.exception_on_unknown_classname` parameter is setted to `false`.

ping @crouillon 