### PR TITLE
Add new events dispatching

### DIFF
--- a/Bundle/AbstractBundle.php
+++ b/Bundle/AbstractBundle.php
@@ -25,6 +25,7 @@ namespace BackBee\Bundle;
 
 use Symfony\Component\Security\Core\Util\ClassUtils;
 use BackBee\ApplicationInterface;
+use BackBee\Bundle\Event\BundleStartEvent;
 use BackBee\Routing\RouteCollection;
 use BackBee\Security\Acl\Domain\ObjectIdentifiableInterface;
 
@@ -226,6 +227,13 @@ abstract class AbstractBundle implements BundleInterface
     public function started()
     {
         $this->started = true;
+
+        if ($this->application->getContainer()->has('event.dispatcher')) {
+            $this->application
+                ->getContainer()
+                ->get('event.dispatcher')
+                ->dispatch(sprintf('bundle.%s.started', $this->getId()), new BundleStartEvent($this));
+        }
     }
 
     /**

--- a/Bundle/Event/AbstractBundleEvent.php
+++ b/Bundle/Event/AbstractBundleEvent.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2017 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Bundle\Event;
+
+use BackBee\Bundle\BundleInterface;
+use BackBee\Event\Event;
+
+/**
+ * An abstract bundle event.
+ *
+ * @author       Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+abstract class AbstractBundleEvent extends Event
+{
+
+    /**
+     * The targeted bundle.
+     *
+     * @var BundleInterface
+     */
+    protected $bundle;
+
+    /**
+     * Event constructor.
+     *
+     * @param  BundleInterface $target
+     * @param  mixed           $eventArgs
+     * @throws \InvalidArgumentException if the provided target does not implement BundleInterface
+     */
+    public function __construct($target, $eventArgs = null)
+    {
+        if (!($target instanceof BundleInterface)) {
+            throw new \InvalidArgumentException(
+                'Target of bundle update or action event must be instance of BackBee\Bundle\BundleInterface'
+            );
+        }
+
+        parent::__construct($target, $eventArgs);
+
+        $this->bundle = $target;
+    }
+
+    /**
+     * Returns the bundle which has just stopped.
+     *
+     * @return
+     */
+    public function getBundle()
+    {
+        return $this->bundle;
+    }
+}

--- a/Bundle/Event/BundleStartEvent.php
+++ b/Bundle/Event/BundleStartEvent.php
@@ -28,7 +28,7 @@ namespace BackBee\Bundle\Event;
  *
  * @author    Charles Rouillon <charles.rouillon@lp-digital.fr>
  */
-class BundleStartEvent extends AbstractBundle
+class BundleStartEvent extends AbstractBundleEvent
 {
 
 }

--- a/Bundle/Event/BundleStartEvent.php
+++ b/Bundle/Event/BundleStartEvent.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2017 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Bundle\Event;
+
+use BackBee\Bundle\BundleInterface;
+use BackBee\Event\Event;
+
+/**
+ * Event dispatch on bundle start.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+class BundleStartEvent extends Event
+{
+
+    /**
+     * The targeted bundle.
+     *
+     * @var BundleInterface
+     */
+    private $bundle;
+
+    /**
+     * Event constructor.
+     *
+     * @param  BundleInterface $target
+     * @param  mixed           $eventArgs
+     * @throws \InvalidArgumentException if the provided target does not implement BackBee\Bundle\BundleInterface
+     */
+    public function __construct($target, $eventArgs = null)
+    {
+        if (!($target instanceof BundleInterface)) {
+            throw new \InvalidArgumentException(
+                'Target of bundle update or action event must be instance of BackBee\Bundle\BundleInterface'
+            );
+        }
+
+        parent::__construct($target, $eventArgs);
+
+        $this->bundle = $target;
+    }
+
+    /**
+     * Returns the bundle which has just started.
+     *
+     * @return
+     */
+    public function getBundle()
+    {
+        return $this->bundle;
+    }
+}

--- a/Bundle/Event/BundleStartEvent.php
+++ b/Bundle/Event/BundleStartEvent.php
@@ -23,51 +23,12 @@
 
 namespace BackBee\Bundle\Event;
 
-use BackBee\Bundle\BundleInterface;
-use BackBee\Event\Event;
-
 /**
  * Event dispatch on bundle start.
  *
- * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ * @author    Charles Rouillon <charles.rouillon@lp-digital.fr>
  */
-class BundleStartEvent extends Event
+class BundleStartEvent extends AbstractBundle
 {
 
-    /**
-     * The targeted bundle.
-     *
-     * @var BundleInterface
-     */
-    private $bundle;
-
-    /**
-     * Event constructor.
-     *
-     * @param  BundleInterface $target
-     * @param  mixed           $eventArgs
-     * @throws \InvalidArgumentException if the provided target does not implement BackBee\Bundle\BundleInterface
-     */
-    public function __construct($target, $eventArgs = null)
-    {
-        if (!($target instanceof BundleInterface)) {
-            throw new \InvalidArgumentException(
-                'Target of bundle update or action event must be instance of BackBee\Bundle\BundleInterface'
-            );
-        }
-
-        parent::__construct($target, $eventArgs);
-
-        $this->bundle = $target;
-    }
-
-    /**
-     * Returns the bundle which has just started.
-     *
-     * @return
-     */
-    public function getBundle()
-    {
-        return $this->bundle;
-    }
 }

--- a/Bundle/Event/BundleStopEvent.php
+++ b/Bundle/Event/BundleStopEvent.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2017 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Bundle\Event;
+
+use BackBee\Bundle\BundleInterface;
+use BackBee\Event\Event;
+
+/**
+ * Event dispatch on bundle stop.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+class BundleStopEvent extends Event
+{
+
+    /**
+     * The targeted bundle.
+     *
+     * @var BundleInterface
+     */
+    private $bundle;
+
+    /**
+     * Event constructor.
+     *
+     * @param  BundleInterface $target
+     * @param  mixed           $eventArgs
+     * @throws \InvalidArgumentException if the provided target does not implement BackBee\Bundle\BundleInterface
+     */
+    public function __construct($target, $eventArgs = null)
+    {
+        if (!($target instanceof BundleInterface)) {
+            throw new \InvalidArgumentException(
+                'Target of bundle update or action event must be instance of BackBee\Bundle\BundleInterface'
+            );
+        }
+
+        parent::__construct($target, $eventArgs);
+
+        $this->bundle = $target;
+    }
+
+    /**
+     * Returns the bundle which has just stopped.
+     *
+     * @return
+     */
+    public function getBundle()
+    {
+        return $this->bundle;
+    }
+}

--- a/Bundle/Event/BundleStopEvent.php
+++ b/Bundle/Event/BundleStopEvent.php
@@ -23,51 +23,12 @@
 
 namespace BackBee\Bundle\Event;
 
-use BackBee\Bundle\BundleInterface;
-use BackBee\Event\Event;
-
 /**
  * Event dispatch on bundle stop.
  *
- * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ * @author    Charles Rouillon <charles.rouillon@lp-digital.fr>
  */
-class BundleStopEvent extends Event
+class BundleStopEvent extends AbstractBundle
 {
 
-    /**
-     * The targeted bundle.
-     *
-     * @var BundleInterface
-     */
-    private $bundle;
-
-    /**
-     * Event constructor.
-     *
-     * @param  BundleInterface $target
-     * @param  mixed           $eventArgs
-     * @throws \InvalidArgumentException if the provided target does not implement BackBee\Bundle\BundleInterface
-     */
-    public function __construct($target, $eventArgs = null)
-    {
-        if (!($target instanceof BundleInterface)) {
-            throw new \InvalidArgumentException(
-                'Target of bundle update or action event must be instance of BackBee\Bundle\BundleInterface'
-            );
-        }
-
-        parent::__construct($target, $eventArgs);
-
-        $this->bundle = $target;
-    }
-
-    /**
-     * Returns the bundle which has just stopped.
-     *
-     * @return
-     */
-    public function getBundle()
-    {
-        return $this->bundle;
-    }
 }

--- a/Bundle/Event/BundleStopEvent.php
+++ b/Bundle/Event/BundleStopEvent.php
@@ -28,7 +28,7 @@ namespace BackBee\Bundle\Event;
  *
  * @author    Charles Rouillon <charles.rouillon@lp-digital.fr>
  */
-class BundleStopEvent extends AbstractBundle
+class BundleStopEvent extends AbstractBundleEvent
 {
 
 }

--- a/Bundle/Listener/BundleListener.php
+++ b/Bundle/Listener/BundleListener.php
@@ -23,6 +23,7 @@
 
 namespace BackBee\Bundle\Listener;
 
+use BackBee\Bundle\Event\BundleStopEvent;
 use BackBee\Event\Event;
 
 /**
@@ -35,6 +36,7 @@ use BackBee\Event\Event;
  */
 class BundleListener
 {
+
     /**
      * Occurs on `bbapplication.stop` event to stop every started bundles.
      *
@@ -46,6 +48,11 @@ class BundleListener
         foreach (array_keys($container->findTaggedServiceIds('bundle')) as $bundleId) {
             if ($container->hasInstanceOf($bundleId)) {
                 $container->get($bundleId)->stop();
+
+                if ($container->has('event.dispatcher')) {
+                    $container->get('event.dispatcher')
+                            ->dispatch(sprintf('bundle.%s.stopped', $bundleId), new BundleStopEvent($container->get($bundleId)));
+                }
             }
         }
     }


### PR DESCRIPTION
This PR introduces two new events:
* `bundle.<<bundle id>>.started` : dispatched after the bundle starts
* `bundle.<<bundle id>>.stopped` : dispatched after the bundle stops