### PR TITLE
[BUGFIX] Ensure unicity of a generated name for an uploaded file.

### DIFF
--- a/Rest/Controller/ResourceController.php
+++ b/Rest/Controller/ResourceController.php
@@ -140,7 +140,7 @@ class ResourceController extends AbstractRestController
     private function buildData($originalName, $extension)
     {
         $tmpDirectory = $this->getApplication()->getTemporaryDir();
-        $fileName = md5($originalName . time()) . '.' . $extension;
+        $fileName = md5($originalName . uniqid('', true)) . '.' . $extension;
 
         $data = [
             'originalname' => $originalName,


### PR DESCRIPTION
Uploading two images with the same original name in the same second generates one same filename.
So only one image is saved.

This patch replaces the descriminator time() by uniqid ('', true) to ensure the unicity of the filename.