### PR TITLE
[Rest] updated SecurityController to encode password with declared encoder

### DIFF
--- a/Rest/Controller/SecurityController.php
+++ b/Rest/Controller/SecurityController.php
@@ -55,7 +55,15 @@ class SecurityController extends AbstractRestController
         $token->setUser($request->request->get('username'));
         $token->setCreated($created);
         $token->setNonce(md5(uniqid('', true)));
-        $token->setDigest(md5($token->getNonce().$created.md5($request->request->get('password'))));
+        $encodedPassword = $this
+            ->getApplication()
+            ->getSecurityContext()
+            ->getEncoderFactory()
+            ->getEncoder('BackBee\Security\User')
+            ->encodePassword($request->request->get('password'))
+        ;
+
+        $token->setDigest(md5($token->getNonce().$created.$encodedPassword));
 
         $tokenAuthenticated = $this->getApplication()->getSecurityContext()->getAuthenticationManager()
             ->authenticate($token)


### PR DESCRIPTION
Currently, `SecurityController::authenticateAction` only encodes password with `md5`. This PR aims to change it by using the declared encoder for `BackBee\Security\User` in `security.yml`.