### PR TITLE
[Rest] updated ResourceController to dispatch ValidateFileUploadEvent

### DIFF
--- a/Rest/Controller/Event/ValidateFileUploadEvent.php
+++ b/Rest/Controller/Event/ValidateFileUploadEvent.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace BackBee\Rest\Controller\Event;
+
+use BackBee\Event\Event;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * @author Eric Chau <eric.chau@lp-digital.fr>
+ */
+class ValidateFileUploadEvent extends Event
+{
+    const EVENT_NAME = 'file_upload.validation';
+
+    protected $filepath;
+
+    /**
+     * @param string $filepath
+     */
+    public function __construct($filepath)
+    {
+        $this->filepath = (string) $filepath;
+
+        parent::__construct($this->filepath);
+    }
+
+    /**
+     * Returns the path of the file to validate.
+     *
+     * @return string
+     */
+    public function getFilepath()
+    {
+        return $this->filepath;
+    }
+
+    /**
+     * Invalidates the provided file by throwing an exception.
+     *
+     * @param  string $message
+     * @throws BadRequestHttpException
+     */
+    public function invalidateFile($message)
+    {
+        unlink($this->filepath);
+
+        throw new BadRequestHttpException($message);
+    }
+}

--- a/Rest/Controller/ResourceController.php
+++ b/Rest/Controller/ResourceController.php
@@ -23,13 +23,13 @@
 
 namespace BackBee\Rest\Controller;
 
+use BackBee\Rest\Controller\Annotations as Rest;
+use BackBee\Rest\Controller\Event\ValidateFileUploadEvent;
+use BackBee\Utils\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-
-use BackBee\Rest\Controller\Annotations as Rest;
-use BackBee\Utils\File\File;
 
 /**
  * REST API for Resources
@@ -126,6 +126,11 @@ class ResourceController extends AbstractRestController
     {
         $data = $this->buildData($originalName, File::getExtension($originalName, false));
         file_put_contents($data['path'], base64_decode($src));
+
+        $this->application->getEventDispatcher()->dispatch(
+            ValidateFileUploadEvent::EVENT_NAME,
+            new ValidateFileUploadEvent($data['path'])
+        );
 
         return $data;
     }


### PR DESCRIPTION
This PR adds a new event: `ValidateFileUploadEvent`. This event is dispatched when a new base64 encoded file is uploaded. By default, BackBee accepts the upload of any files. In some cases, you may want to be able to restrict the upload of images only.