### PR TITLE
[BUGFIX] Ensure the project view repository is always the first one included

### DIFF
--- a/Renderer/AbstractRenderer.php
+++ b/Renderer/AbstractRenderer.php
@@ -331,7 +331,7 @@ abstract class AbstractRenderer implements RendererInterface
      * @param strimg  $new_dir  location of the new directory
      * @param integer $position position in the array
      */
-    public function addScriptDir($new_dir, $position = 0)
+    public function addScriptDir($new_dir, $position = 1)
     {
         if (true === file_exists($new_dir) && true === is_dir($new_dir)) {
             $this->insertInArrayOnPostion($this->_scriptdir, $new_dir, $position);


### PR DESCRIPTION
While loading a bundle, the view directory of the bundle was included as first position, avoiding the overriding of its views.

Setting the default position to 1 ensures to keep the project veiw repository as the first one included while looking for templates.