### PR TITLE
[MISC] Remove support of PHP < 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: php
 sudo: false
 
 php:
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.6.0",
         "psr/log": "~1.0",
         "symfony/config": "~2.7.0",
         "symfony/console": "~2.7.0",


### PR DESCRIPTION
Resolved [#784](https://github.com/backbee/backbee-php/issues/784)
Due to an update of doctrine/common, php < 5.6 can no more be supported 